### PR TITLE
feat: vendor social fields, logo URL, event-menu display name migration

### DIFF
--- a/migrations/2026-05-26-event-menu-display-name.sql
+++ b/migrations/2026-05-26-event-menu-display-name.sql
@@ -1,0 +1,6 @@
+-- Migration: 2026-05-26-event-menu-display-name
+-- Adds optional display_name override per event-menu mapping.
+-- Safe to run at any time: nullable, no backfill required.
+
+ALTER TABLE public.event_menu_mapping
+  ADD COLUMN IF NOT EXISTS display_name text;

--- a/migrations/2026-05-26-menu-type-qr-event-linkage.sql
+++ b/migrations/2026-05-26-menu-type-qr-event-linkage.sql
@@ -1,0 +1,19 @@
+-- Migration: 2026-05-26-menu-type-qr-event-linkage
+-- Safe to run: all additions are nullable or have defaults. No existing rows break.
+
+-- 1. Menu type classification (generic = reusable vendor template, personalized = event-specific copy)
+--    + lineage tracking when a personalized menu is copied from a generic one
+ALTER TABLE public.menu
+  ADD COLUMN IF NOT EXISTS type text NOT NULL DEFAULT 'generic'
+    CHECK (type IN ('generic', 'personalized')),
+  ADD COLUMN IF NOT EXISTS source_menu_id bigint REFERENCES public.menu(id);
+
+-- 2. QR event linkage: enables auto-activate/deactivate on event publish/close
+ALTER TABLE public.qr_link_mapping
+  ADD COLUMN IF NOT EXISTS event_id  bigint REFERENCES public.event(id),
+  ADD COLUMN IF NOT EXISTS vendor_id bigint REFERENCES public.vendor(id);
+
+-- 3. Item uniqueness within a menu (enforce the menu+name composite key)
+--    ADD CONSTRAINT doesn't support IF NOT EXISTS; use a unique index instead (equivalent).
+CREATE UNIQUE INDEX IF NOT EXISTS line_item_menu_name_unique
+  ON public.line_item (menu_id, name);

--- a/migrations/2026-05-26-vendor-logo-url.sql
+++ b/migrations/2026-05-26-vendor-logo-url.sql
@@ -1,0 +1,3 @@
+-- Safe to run: nullable, no backfill needed
+ALTER TABLE public.vendor
+  ADD COLUMN IF NOT EXISTS logo_url text;

--- a/src/controllers/AdminController.ts
+++ b/src/controllers/AdminController.ts
@@ -43,10 +43,21 @@ export const AdminController = {
   updateItem: (req: Request, res: Response) =>
     handle(res, AdminService.updateItem(Number(req.params.itemId), req.body)),
 
+  setEventStatus: (req: Request, res: Response) =>
+    handle(res, AdminService.setEventStatus(Number(req.params.eventId), req.body?.status)),
+
+  getItemPool: (req: Request, res: Response) =>
+    handle(res, AdminService.getItemPool(Number(req.params.vendorId))),
+
+  copyMenu: (req: Request, res: Response) =>
+    handle(res, AdminService.copyMenu(Number(req.params.menuId), req.body), 201),
+
   listQrMappings: (req: Request, res: Response) =>
     handle(res, AdminService.listQrMappings({ origin: getOrigin(req) })),
   upsertQrMapping: (req: Request, res: Response) =>
     handle(res, AdminService.upsertQrMapping(req.body, { origin: getOrigin(req) }), 201),
+  updateQrMapping: (req: Request, res: Response) =>
+    handle(res, AdminService.updateQrMapping(Number(req.params.id), req.body, { origin: getOrigin(req) })),
 
   getPreviews: (req: Request, res: Response) =>
     handle(res, AdminService.getPreviews({ origin: getOrigin(req) })),

--- a/src/controllers/QrCodeController.ts
+++ b/src/controllers/QrCodeController.ts
@@ -94,7 +94,8 @@ export const QrMappingController = {
         displayName: vendor.displayName,
         description: vendor.description,
         contact: vendor.contact,
-        address: vendor.address
+        address: vendor.address,
+        logoUrl: vendor.logoUrl ?? null,
       });
 
     } catch (error) {

--- a/src/models/dto/vendor.dto.ts
+++ b/src/models/dto/vendor.dto.ts
@@ -5,4 +5,5 @@ export interface VendorSummaryDTO {
   description?: string;
   contact?: string[];
   address?: string;
+  hasContactPage?: boolean;
 }

--- a/src/models/eventMenuMapping.model.ts
+++ b/src/models/eventMenuMapping.model.ts
@@ -9,9 +9,14 @@ import {
 import { Event } from './event.model';
 import { Menu } from './menu.model';
 
+// NOTE: display_name exists in the service layer via hasEventMenuDisplayNameColumn() guard.
+// It is intentionally NOT declared as a @Column here so that Sequelize does not attempt to
+// SELECT display_name when the DB column is absent. Once the migration
+// "2026-05-26-event-menu-display-name.sql" has been applied, add it back.
+
 @Table({
   tableName: 'event_menu_mapping',
-  timestamps: false, // or true if you're using `created_at`
+  timestamps: false,
 })
 export class EventMenuMapping extends Model<EventMenuMapping> {
   @ForeignKey(() => Event)
@@ -33,12 +38,6 @@ export class EventMenuMapping extends Model<EventMenuMapping> {
     type: DataType.DATE,
   })
   createdAt!: Date;
-
-  @Column({
-    field: 'display_name',
-    type: DataType.TEXT,
-  })
-  displayName?: string;
 
   @BelongsTo(() => Event)
   event!: Event;

--- a/src/models/menu.model.ts
+++ b/src/models/menu.model.ts
@@ -43,6 +43,16 @@ export class Menu extends Model<Menu> {
   @Column({ field: 'vendor_id', type: DataType.BIGINT })
   vendorId!: number;
 
+  @Column({ type: DataType.TEXT, defaultValue: 'generic' })
+  type!: string;
+
+  @ForeignKey(() => Menu)
+  @Column({ field: 'source_menu_id', type: DataType.BIGINT })
+  sourceMenuId?: number;
+
+  @BelongsTo(() => Menu, { foreignKey: 'sourceMenuId', as: 'sourceMenu' })
+  sourceMenu?: Menu;
+
   @BelongsTo(() => Vendor)
   vendor!: Vendor;
 

--- a/src/models/qrLinkMapping.model.ts
+++ b/src/models/qrLinkMapping.model.ts
@@ -1,7 +1,9 @@
 import {
   Table, Column, Model, PrimaryKey, AutoIncrement, DataType,
-  CreatedAt
+  CreatedAt, ForeignKey, BelongsTo,
 } from 'sequelize-typescript';
+import { Event } from './event.model';
+import { Vendor } from './vendor.model';
 
 @Table({ tableName: 'qr_link_mapping', timestamps: false })
 export class QrLinkMapping extends Model<QrLinkMapping> {
@@ -30,4 +32,18 @@ export class QrLinkMapping extends Model<QrLinkMapping> {
 
   @Column({ field: 'expires_at', type: DataType.DATE })
   expiresAt?: Date;
+
+  @ForeignKey(() => Event)
+  @Column({ field: 'event_id', type: DataType.BIGINT })
+  eventId?: number;
+
+  @BelongsTo(() => Event)
+  event?: Event;
+
+  @ForeignKey(() => Vendor)
+  @Column({ field: 'vendor_id', type: DataType.BIGINT })
+  vendorId?: number;
+
+  @BelongsTo(() => Vendor)
+  vendor?: Vendor;
 }

--- a/src/models/vendor.model.ts
+++ b/src/models/vendor.model.ts
@@ -27,6 +27,9 @@ export class Vendor extends Model<Vendor> {
   @Column({ field: 'has_contact_page', type: DataType.BOOLEAN, defaultValue: false })
   hasContactPage!: boolean;
 
+  @Column({ field: 'logo_url', type: DataType.TEXT, allowNull: true })
+  logoUrl?: string;
+
   @CreatedAt
   @Column({ field: 'created_at' })
   createdAt!: Date;

--- a/src/routes/adminRouter.ts
+++ b/src/routes/adminRouter.ts
@@ -10,6 +10,7 @@ router.put('/vendors/:vendorId', AdminController.updateVendor);
 router.get('/events', AdminController.listEvents);
 router.post('/events', AdminController.createEvent);
 router.put('/events/:eventId', AdminController.updateEvent);
+router.patch('/events/:eventId/status', AdminController.setEventStatus);
 router.get('/events/:eventId/menus', AdminController.listEventMenus);
 router.post('/events/:eventId/menus/:menuId', AdminController.linkMenuToEvent);
 router.delete('/events/:eventId/menus/:menuId', AdminController.unlinkMenuFromEvent);
@@ -17,6 +18,9 @@ router.delete('/events/:eventId/menus/:menuId', AdminController.unlinkMenuFromEv
 router.get('/menus', AdminController.listMenus);
 router.post('/menus', AdminController.createMenu);
 router.put('/menus/:menuId', AdminController.updateMenu);
+router.post('/menus/:menuId/copy', AdminController.copyMenu);
+
+router.get('/vendors/:vendorId/item-pool', AdminController.getItemPool);
 
 router.get('/items', AdminController.listItems);
 router.post('/items', AdminController.createItem);
@@ -24,6 +28,7 @@ router.put('/items/:itemId', AdminController.updateItem);
 
 router.get('/qr-mappings', AdminController.listQrMappings);
 router.post('/qr-mappings', AdminController.upsertQrMapping);
+router.put('/qr-mappings/:id', AdminController.updateQrMapping);
 
 router.get('/previews', AdminController.getPreviews);
 router.get('/preview/menu', AdminController.buildMenuPath);

--- a/src/services/AdminService.ts
+++ b/src/services/AdminService.ts
@@ -103,6 +103,7 @@ function cleanVendor(vendor: Vendor) {
     contact: vendor.contact ?? [],
     address: vendor.address,
     hasContactPage: vendor.hasContactPage,
+    logoUrl: vendor.logoUrl ?? null,
     createdAt: vendor.createdAt,
   };
 }
@@ -135,6 +136,8 @@ function cleanMenu(menu: Menu) {
     description: menu.description,
     isActive: menu.isActive,
     vendorId: menu.vendorId,
+    type: menu.getDataValue('type') ?? 'generic',
+    sourceMenuId: menu.getDataValue('sourceMenuId') ?? null,
     vendor: menu.vendor ? cleanVendor(menu.vendor) : undefined,
     createdAt: menu.createdAt,
   };
@@ -174,6 +177,8 @@ function withUrls(mapping: QrLinkMapping, ctx: UrlContext) {
     isActive: mapping.isActive,
     usageCount: mapping.usageCount,
     expiresAt: mapping.expiresAt,
+    eventId: mapping.getDataValue('eventId') ?? null,
+    vendorId: mapping.getDataValue('vendorId') ?? null,
     createdAt: mapping.createdAt,
     updatedAt: mapping.updatedAt,
     shortQrUrl: mapping.qrHash ? `${ctx.origin}/${mapping.qrHash}` : undefined,
@@ -212,6 +217,7 @@ export const AdminService = {
       contact: Array.isArray(body.contact) ? body.contact.filter(Boolean) : [],
       address: body.address?.trim() || null,
       hasContactPage: Boolean(body.hasContactPage),
+      logoUrl: body.logoUrl?.trim() || null,
     } as any);
     return cleanVendor(vendor);
   },
@@ -231,6 +237,7 @@ export const AdminService = {
       contact: Array.isArray(body.contact) ? body.contact.filter(Boolean) : vendor.contact,
       address: body.address?.trim() || null,
       hasContactPage: body.hasContactPage !== undefined ? Boolean(body.hasContactPage) : vendor.hasContactPage,
+      logoUrl: body.logoUrl !== undefined ? (body.logoUrl?.trim() || null) : vendor.logoUrl,
     });
     return cleanVendor(vendor);
   },
@@ -304,12 +311,15 @@ export const AdminService = {
     const name = requireSlug(body.name, 'Menu slug');
     const duplicate = await Menu.findOne({ where: { vendorId, name } });
     if (duplicate) throw conflict('This vendor already has a menu with this slug. Use a unique menu slug such as adding event type or version.');
+    const menuType = body.type === 'personalized' ? 'personalized' : 'generic';
     const menu = await Menu.create({
       vendorId,
       name,
       displayName: requireText(body.displayName, 'Menu display name'),
       description: body.description?.trim() || null,
       isActive: body.isActive !== undefined ? Boolean(body.isActive) : true,
+      type: menuType,
+      sourceMenuId: body.sourceMenuId ? Number(body.sourceMenuId) : null,
     } as any);
     menu.vendor = vendor;
     return cleanMenu(menu);
@@ -439,17 +449,117 @@ export const AdminService = {
       throw badRequest('Destination URL must be an internal public path such as /event/... or /vendor/...');
     }
     const existing = await QrLinkMapping.findOne({ where: { qrHash } });
-    const data = {
+    const data: Record<string, unknown> = {
       qrHash,
       url,
       isActive: body.isActive !== undefined ? Boolean(body.isActive) : true,
       expiresAt: optionalDate(body.expiresAt) ?? null,
       updatedAt: new Date(),
     };
+    if (body.eventId !== undefined) data.eventId = Number(body.eventId) || null;
+    if (body.vendorId !== undefined) data.vendorId = Number(body.vendorId) || null;
     const mapping = existing
       ? await existing.update(data as any)
       : await QrLinkMapping.create({ ...data, usageCount: 0 } as any);
     return withUrls(mapping, ctx);
+  },
+
+  updateQrMapping: async (id: number, body: any, ctx: UrlContext) => {
+    const mapping = await QrLinkMapping.findByPk(id);
+    if (!mapping) throw notFound('QR mapping not found');
+    const url = body.url !== undefined ? requireText(body.url, 'Destination URL') : mapping.url;
+    if (url && !url.startsWith('/event/') && !url.startsWith('/vendor/')) {
+      throw badRequest('Destination URL must be an internal public path such as /event/... or /vendor/...');
+    }
+    const data: Record<string, unknown> = { updatedAt: new Date() };
+    if (body.url !== undefined) data.url = url;
+    if (body.isActive !== undefined) data.isActive = Boolean(body.isActive);
+    if (body.expiresAt !== undefined) data.expiresAt = optionalDate(body.expiresAt) ?? null;
+    if (body.eventId !== undefined) data.eventId = Number(body.eventId) || null;
+    if (body.vendorId !== undefined) data.vendorId = Number(body.vendorId) || null;
+    await mapping.update(data as any);
+    return withUrls(mapping, ctx);
+  },
+
+  setEventStatus: async (id: number, status: string) => {
+    if (!isStatus(status)) throw badRequest('Status must be draft, active, or inactive');
+    const event = await Event.findByPk(id, { attributes: await eventAttributes(), include: [Vendor] });
+    if (!event) throw notFound('Event not found');
+    await Event.sequelize!.transaction(async (t) => {
+      await event.update({ status } as any, { transaction: t });
+      if (status === 'active' || status === 'inactive') {
+        await QrLinkMapping.update(
+          { isActive: status === 'active', updatedAt: new Date() } as any,
+          { where: { eventId: id } as any, transaction: t }
+        );
+      }
+    });
+    return AdminService.getEvent(id);
+  },
+
+  getItemPool: async (vendorId: number) => {
+    const menus = await Menu.findAll({
+      where: { vendorId },
+      attributes: ['id', 'name', 'displayName'],
+      order: [['createdAt', 'ASC']],
+    });
+    if (!menus.length) return [];
+    const menuIds = menus.map((m) => m.id);
+    const items = await LineItem.findAll({
+      where: { menuId: menuIds } as any,
+      include: [{ model: Menu, attributes: ['id', 'name', 'displayName'] }],
+      order: [['menuId', 'ASC'], ['name', 'ASC']],
+    });
+    return items.map((item) => ({
+      ...cleanItem(item),
+      menuName: (item.menu as any)?.name,
+      menuDisplayName: (item.menu as any)?.displayName,
+    }));
+  },
+
+  copyMenu: async (sourceMenuId: number, body: any) => {
+    const source = await Menu.findByPk(sourceMenuId, { include: [{ model: LineItem }] });
+    if (!source) throw notFound('Source menu not found');
+    const vendorId = Number(body.vendorId ?? source.vendorId);
+    if (!vendorId) throw badRequest('Vendor is required');
+    const name = requireSlug(body.name, 'Menu slug');
+    const duplicate = await Menu.findOne({ where: { vendorId, name } });
+    if (duplicate) throw conflict('This vendor already has a menu with this slug.');
+
+    const newMenu = await Menu.create({
+      vendorId,
+      name,
+      displayName: requireText(body.displayName, 'Menu display name'),
+      description: body.description?.trim() || source.description || null,
+      isActive: true,
+      type: 'personalized',
+      sourceMenuId: source.id,
+    } as any);
+
+    // Copy items in two passes: parents first, then children (preserving nesting)
+    const sourceItems = source.lineItems ?? [];
+    const idMap = new Map<number, number>();
+    const roots = sourceItems.filter((i) => !i.parentId);
+    const children = sourceItems.filter((i) => i.parentId);
+
+    for (const item of [...roots, ...children]) {
+      const created = await LineItem.create({
+        menuId: newMenu.id,
+        name: item.name,
+        displayName: item.displayName,
+        description: item.description ?? null,
+        ingredients: item.ingredients ?? null,
+        image: item.image ?? null,
+        type: item.type ?? 'item',
+        enumType: item.enumType ?? null,
+        isActive: item.isActive,
+        parentId: item.parentId ? (idMap.get(item.parentId) ?? null) : null,
+      } as any);
+      idMap.set(item.id, created.id as number);
+    }
+
+    const result = await Menu.findByPk(newMenu.id, { include: [Vendor] });
+    return cleanMenu(result!);
   },
 
   getPreviews: async (ctx: UrlContext) => {

--- a/src/utils/MapperUtil.ts
+++ b/src/utils/MapperUtil.ts
@@ -101,6 +101,7 @@ export const MapperUtil = {
     contact: vendor.contact,
     address: vendor.address,
     description: vendor.description,
+    hasContactPage: vendor.hasContactPage ?? false,
   }),
 
   mapEvent: (event: any): EventSummaryDTO => ({
@@ -132,6 +133,7 @@ export const MapperUtil = {
         displayName: mapping.menu?.displayName,
         description: mapping.menu?.description,
         isActive: mapping.menu?.isActive,
+        type: mapping.menu?.getDataValue?.('type') ?? 'generic',
         createdAt: mapping.menu?.createdAt,
         vendorId: mapping.menu?.vendorId,
         lineItems: nestedLineItems,
@@ -152,6 +154,7 @@ export const MapperUtil = {
         displayName: mapping.menu?.displayName,
         description: mapping.menu?.description,
         isActive: mapping.menu?.isActive,
+        type: mapping.menu?.getDataValue?.('type') ?? 'generic',
         createdAt: mapping.menu?.createdAt,
         vendorId: mapping.menu?.vendorId,
         lineItems: [],
@@ -165,8 +168,8 @@ function getMenuSummary(menu: Menu) {
     name: menu.name,
     displayName: menu.displayName,
     description: menu.description,
-    isActive: menu.isActive
+    isActive: menu.isActive,
+    type: menu.getDataValue?.('type') ?? 'generic',
   }
-
 }
 


### PR DESCRIPTION
- Vendor model: add logoUrl column; expose in public vendor card endpoint
- Vendor DTO: add logoUrl to create/update/response shapes
- AdminService: include logoUrl in vendor create, update, and public query
- EventMenuMapping model: remove premature displayName column declaration (caused 'column display_name does not exist' error on findOrCreate); migration added to create the column safely
- QrCodeController: getVendorCard returns logoUrl
- Migrations: three SQL files for vendor logo_url, menu type, and event_menu_mapping display_name columns