### PR TITLE
fix(ts): cast dynamic 'displayName' column key to any in mappingDispl…

### DIFF
--- a/src/services/AdminService.ts
+++ b/src/services/AdminService.ts
@@ -53,7 +53,9 @@ async function eventMenuMappingAttributes() {
 }
 
 function mappingDisplayName(mapping: EventMenuMapping) {
-  return mapping.getDataValue('displayName') || mapping.menu.displayName;
+  // 'displayName' is not declared on EventMenuMapping because the column is conditionally
+  // present (see hasEventMenuDisplayNameColumn). Cast to any so TS doesn't reject it.
+  return mapping.getDataValue('displayName' as any) || mapping.menu.displayName;
 }
 
 function badRequest(message: string) {


### PR DESCRIPTION
…ayName

display_name is conditionally present on event_menu_mapping (added via literal() when the column exists). It is intentionally not declared as a @Column so Sequelize doesn't SELECT it when absent. Cast 'displayName' to any to satisfy getDataValue's keyof constraint without changing runtime behaviour.