### PR TITLE
feat(qr): reusable event QR with auto-sync layer

### DIFF
--- a/migrations/2026-05-28-qr-type-column.sql
+++ b/migrations/2026-05-28-qr-type-column.sql
@@ -1,0 +1,6 @@
+-- Add 'type' column to qr_link_mapping for dynamic event-based QR resolution.
+-- 'static'  = legacy behaviour, redirect uses the stored url field
+-- 'event'   = dynamic, resolves to the event's current linked menu at scan time
+-- 'vendor'  = (future) dynamic vendor card resolution
+ALTER TABLE qr_link_mapping
+  ADD COLUMN IF NOT EXISTS type VARCHAR(20) NOT NULL DEFAULT 'static';

--- a/src/controllers/AdminController.ts
+++ b/src/controllers/AdminController.ts
@@ -58,6 +58,8 @@ export const AdminController = {
     handle(res, AdminService.upsertQrMapping(req.body, { origin: getOrigin(req) }), 201),
   updateQrMapping: (req: Request, res: Response) =>
     handle(res, AdminService.updateQrMapping(Number(req.params.id), req.body, { origin: getOrigin(req) })),
+  getOrCreateEventQr: (req: Request, res: Response) =>
+    handle(res, AdminService.getOrCreateEventQr(Number(req.params.eventId), { origin: getOrigin(req) }), 201),
 
   listQrTemplates: (_req: Request, res: Response) => handle(res, AdminService.listQrTemplates()),
   createQrTemplate: (req: Request, res: Response) => handle(res, AdminService.createQrTemplate(req.body), 201),

--- a/src/models/qrLinkMapping.model.ts
+++ b/src/models/qrLinkMapping.model.ts
@@ -21,6 +21,10 @@ export class QrLinkMapping extends Model<QrLinkMapping> {
   @Column(DataType.TEXT)
   url?: string;
 
+  // 'static' = redirect to stored url | 'event' = dynamically resolve current menu | 'vendor' = future
+  @Column({ type: DataType.STRING(20), defaultValue: 'static' })
+  type?: string;
+
   @Column({ field: 'updated_at', type: DataType.DATE })
   updatedAt?: Date;
 

--- a/src/routes/adminRouter.ts
+++ b/src/routes/adminRouter.ts
@@ -32,6 +32,7 @@ router.delete('/items/:itemId', AdminController.deleteItem);
 
 router.get('/qr-mappings', AdminController.listQrMappings);
 router.post('/qr-mappings', AdminController.upsertQrMapping);
+router.post('/qr-mappings/for-event/:eventId', AdminController.getOrCreateEventQr);
 router.put('/qr-mappings/:id', AdminController.updateQrMapping);
 router.delete('/qr-mappings/:id', AdminController.deleteQrMapping);
 

--- a/src/services/AdminService.ts
+++ b/src/services/AdminService.ts
@@ -175,20 +175,41 @@ function itemPath(eventName: string, menuName: string, itemName: string) {
 
 function withUrls(mapping: QrLinkMapping, ctx: UrlContext) {
   const destination = mapping.url?.startsWith('/') ? mapping.url : mapping.url ? `/${mapping.url}` : undefined;
+  const type = (mapping.type || 'static') as string;
   return {
     id: mapping.id,
     qrHash: mapping.qrHash,
     url: mapping.url,
+    type,
     isActive: mapping.isActive,
     usageCount: mapping.usageCount,
     expiresAt: mapping.expiresAt,
-    eventId: mapping.getDataValue('eventId') ?? null,
-    vendorId: mapping.getDataValue('vendorId') ?? null,
+    eventId: mapping.getDataValue('eventId') != null ? Number(mapping.getDataValue('eventId')) : null,
+    vendorId: mapping.getDataValue('vendorId') != null ? Number(mapping.getDataValue('vendorId')) : null,
     createdAt: mapping.createdAt,
     updatedAt: mapping.updatedAt,
     shortQrUrl: mapping.qrHash ? `${ctx.origin}/${mapping.qrHash}` : undefined,
     finalPublicUrl: destination ? `${ctx.origin}${destination}` : undefined,
   };
+}
+
+// When menus are linked/unlinked, keep all event-type QRs for this event
+// pointing to the current first linked menu. Pure URL update — redirect logic unchanged.
+async function syncEventQrUrls(eventId: number, eventName: string) {
+  const links = await EventMenuMapping.findAll({
+    where: { eventId },
+    attributes: await eventMenuMappingAttributes(),
+    include: [{ model: Menu, attributes: ['name'] }],
+    order: [['createdAt', 'ASC']],
+  });
+  const firstMenu = links[0]?.menu;
+  const url = firstMenu
+    ? `/event/${eventName}/menu/${firstMenu.name}`
+    : `/event/${eventName}`;
+  await QrLinkMapping.update(
+    { url, updatedAt: new Date() },
+    { where: { eventId, type: 'event' } as any }
+  );
 }
 
 async function ensureVendorOwnsMenu(vendorId: number, menuId: number) {
@@ -362,11 +383,16 @@ export const AdminService = {
     if (displayName?.trim() && await hasEventMenuDisplayNameColumn()) {
       await mapping.update({ displayName: displayName.trim() } as any);
     }
+    // Keep any assigned event QRs pointing to the current first menu
+    await syncEventQrUrls(eventId, event.name);
     return AdminService.listEventMenus(eventId);
   },
 
   unlinkMenuFromEvent: async (eventId: number, menuId: number) => {
     await EventMenuMapping.destroy({ where: { eventId, menuId } });
+    // Re-sync so QR URL updates to next menu (or falls back to event page if none left)
+    const event = await Event.findByPk(eventId, { attributes: ['id', 'name'] });
+    if (event) await syncEventQrUrls(eventId, event.name);
     return AdminService.listEventMenus(eventId);
   },
 
@@ -450,14 +476,26 @@ export const AdminService = {
 
   upsertQrMapping: async (body: any, ctx: UrlContext) => {
     const qrHash = requireSlug(body.qrHash, 'QR hash');
-    const url = requireText(body.url, 'Destination URL');
-    if (!url.startsWith('/')) {
-      throw badRequest('Destination URL must be an internal path starting with /');
+    const type = body.type === 'event' ? 'event' : 'static';
+    let url: string | null = null;
+    if (type === 'event') {
+      // Auto-build the event-level URL from eventId so the pure redirect model still works
+      const eventId = Number(body.eventId);
+      if (!eventId) throw badRequest('Event is required for event-type QRs');
+      const event = await Event.findByPk(eventId, { attributes: ['name'] });
+      if (!event) throw badRequest('Event not found');
+      url = `/event/${event.name}`;
+    } else {
+      url = requireText(body.url, 'Destination URL');
+      if (!url.startsWith('/')) {
+        throw badRequest('Destination URL must be an internal path starting with /');
+      }
     }
     const existing = await QrLinkMapping.findOne({ where: { qrHash } });
     const data: Record<string, unknown> = {
       qrHash,
       url,
+      type,
       isActive: body.isActive !== undefined ? Boolean(body.isActive) : true,
       expiresAt: optionalDate(body.expiresAt) ?? null,
       updatedAt: new Date(),
@@ -473,18 +511,60 @@ export const AdminService = {
   updateQrMapping: async (id: number, body: any, ctx: UrlContext) => {
     const mapping = await QrLinkMapping.findByPk(id);
     if (!mapping) throw notFound('QR mapping not found');
-    const url = body.url !== undefined ? requireText(body.url, 'Destination URL') : mapping.url;
-    if (url && !url.startsWith('/')) {
-      throw badRequest('Destination URL must be an internal path starting with /');
+    const type = body.type !== undefined ? (body.type === 'event' ? 'event' : 'static') : (mapping.type || 'static');
+    let url = mapping.url;
+    if (body.url !== undefined) {
+      if (type === 'event') {
+        // Keep the url derived from eventId; if eventId changes, recompute
+        if (body.eventId !== undefined) {
+          const event = await Event.findByPk(Number(body.eventId), { attributes: ['name'] });
+          url = event ? `/event/${event.name}` : mapping.url;
+        }
+      } else {
+        url = requireText(body.url, 'Destination URL');
+        if (!url.startsWith('/')) throw badRequest('Destination URL must be an internal path starting with /');
+      }
     }
-    const data: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.url !== undefined) data.url = url;
+    const data: Record<string, unknown> = { updatedAt: new Date(), type };
+    if (body.url !== undefined || body.type !== undefined || body.eventId !== undefined) data.url = url;
     if (body.isActive !== undefined) data.isActive = Boolean(body.isActive);
     if (body.expiresAt !== undefined) data.expiresAt = optionalDate(body.expiresAt) ?? null;
     if (body.eventId !== undefined) data.eventId = Number(body.eventId) || null;
     if (body.vendorId !== undefined) data.vendorId = Number(body.vendorId) || null;
     await mapping.update(data as any);
     return withUrls(mapping, ctx);
+  },
+
+  getOrCreateEventQr: async (eventId: number, ctx: UrlContext) => {
+    const event = await Event.findByPk(eventId, { attributes: await eventAttributes() });
+    if (!event) throw notFound('Event not found');
+
+    // Return existing event-dynamic QR if one exists
+    const existing = await QrLinkMapping.findOne({ where: { eventId, type: 'event' } as any });
+    if (existing) return withUrls(existing, ctx);
+
+    // Build a unique hash: prefer event slug, add suffix if taken
+    let qrHash = event.name;
+    if (await QrLinkMapping.findOne({ where: { qrHash } })) {
+      qrHash = `${event.name}-qr`;
+    }
+    if (await QrLinkMapping.findOne({ where: { qrHash } })) {
+      qrHash = `${event.name}-${Date.now().toString(36)}`;
+    }
+
+    const mapping = await QrLinkMapping.create({
+      qrHash,
+      url: `/event/${event.name}`,  // placeholder; syncEventQrUrls immediately overwrites if menus exist
+      type: 'event',
+      eventId,
+      vendorId: event.vendorId,
+      isActive: true,
+      usageCount: 0,
+    } as any);
+    // Immediately sync so the URL reflects current linked menus (if any)
+    await syncEventQrUrls(eventId, event.name);
+    const updated = await QrLinkMapping.findByPk(mapping.id);
+    return withUrls(updated!, ctx);
   },
 
   setEventStatus: async (id: number, status: string) => {

--- a/src/services/QrLinkMappingService.ts
+++ b/src/services/QrLinkMappingService.ts
@@ -1,4 +1,3 @@
-import { QrLinkMapping } from '../models/qrLinkMapping.model';
 import { QrLinkMappingRepo } from '../repositories/qrLinkMapping.repository';
 import { Event } from '../models/event.model';
 import { Menu } from '../models/menu.model';
@@ -39,12 +38,12 @@ async function normalizeDestination(url: string) {
 export const QrLinkMappingService = {
 
     getHashRedirectionUrl: async (qrHash: string): Promise<{ redirectionUrl: string } | null> => {
-        const qrLinkMapping: QrLinkMapping | null = await QrLinkMappingRepo.getByHash(qrHash);
+        const qrLinkMapping = await QrLinkMappingRepo.getByHash(qrHash);
 
         if (!qrLinkMapping || !qrLinkMapping.url || !qrLinkMapping.isActive) {
-            return null; // no mapping found
+            return null;
         }
-        
+
         return { redirectionUrl: await normalizeDestination(qrLinkMapping.url) };
     }
 };


### PR DESCRIPTION
New model: qr_link_mapping gains a 'type' column (static | event). Event-type QRs are created with a real URL (/event/{slug}/menu/{menu}) and kept current automatically — no manual URL maintenance needed.

Core redirect service (QrLinkMappingService) is unchanged. The new syncEventQrUrls() helper runs whenever menus are linked/unlinked from an event, updating all assigned event-type QR URLs in place so physical printed QRs stay valid across menu and event rotations.

New endpoint: POST /api/admin/qr-mappings/for-event/:eventId
- Finds or creates the event QR with the correct current URL
- Returns immediately if one already exists