### PR TITLE
feat: vendor login phone management + fix 2factor voice call

### DIFF
--- a/src/services/AdminService.ts
+++ b/src/services/AdminService.ts
@@ -100,6 +100,18 @@ function isStatus(value: unknown) {
   return value === 'draft' || value === 'active' || value === 'inactive';
 }
 
+/** Normalise a login phone to E.164 (+91XXXXXXXXXX) or null if blank. */
+function normalizeLoginPhone(raw: unknown): string | null {
+  if (!raw || typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('+')) return trimmed;
+  const digits = trimmed.replace(/\D/g, '');
+  if (digits.length === 10) return `+91${digits}`;
+  if (digits.length === 12 && digits.startsWith('91')) return `+${digits}`;
+  return trimmed;
+}
+
 function cleanVendor(vendor: Vendor) {
   return {
     id: vendor.id,
@@ -110,6 +122,8 @@ function cleanVendor(vendor: Vendor) {
     address: vendor.address,
     hasContactPage: vendor.hasContactPage,
     logoUrl: vendor.logoUrl ?? null,
+    loginPhone: vendor.phone ?? null,
+    requireLogin: vendor.requireLogin,
     createdAt: vendor.createdAt,
   };
 }
@@ -245,6 +259,8 @@ export const AdminService = {
       address: body.address?.trim() || null,
       hasContactPage: Boolean(body.hasContactPage),
       logoUrl: body.logoUrl?.trim() || null,
+      phone: normalizeLoginPhone(body.loginPhone),
+      requireLogin: Boolean(body.requireLogin),
     } as any);
     return cleanVendor(vendor);
   },
@@ -265,6 +281,8 @@ export const AdminService = {
       address: body.address?.trim() || null,
       hasContactPage: body.hasContactPage !== undefined ? Boolean(body.hasContactPage) : vendor.hasContactPage,
       logoUrl: body.logoUrl !== undefined ? (body.logoUrl?.trim() || null) : vendor.logoUrl,
+      phone: ('loginPhone' in body ? normalizeLoginPhone(body.loginPhone) : vendor.phone) as string | undefined,
+      requireLogin: body.requireLogin !== undefined ? Boolean(body.requireLogin) : vendor.requireLogin,
     });
     return cleanVendor(vendor);
   },

--- a/src/services/SmsService.ts
+++ b/src/services/SmsService.ts
@@ -54,7 +54,9 @@ async function sendVia2Factor(phone: string, otp: string): Promise<void> {
   const apiKey = process.env.TWOFACTOR_API_KEY;
   if (!apiKey) { mockLog(phone, otp, '2factor'); return; }
 
-  const path = `/API/V1/${apiKey}/SMS/${to10Digit(phone)}/${otp}/AUTOGEN`;
+  // No /AUTOGEN suffix — that flag tells 2factor to generate its own OTP (triggers voice fallback).
+  // We pass our own OTP, so just use the plain SMS endpoint.
+  const path = `/API/V1/${apiKey}/SMS/${to10Digit(phone)}/${otp}`;
   await httpGet('2factor.in', path, '2Factor');
 }
 


### PR DESCRIPTION
AdminService: expose loginPhone/requireLogin on vendor GET/POST/PUT
- cleanVendor() now returns loginPhone and requireLogin fields
- createVendor/updateVendor accept loginPhone (normalized to +91XXXXXXXXXX) and requireLogin from request body

SmsService: fix 2factor.in sending voice calls instead of SMS
- Remove /AUTOGEN suffix from the API path — AUTOGEN tells 2factor to generate its own OTP and can trigger a voice fallback. We pass our own 6-digit OTP so the plain SMS endpoint is correct: /API/V1/{key}/SMS/{phone}/{otp}