### PR TITLE
security: require auth on all admin and analytics read endpoints

### DIFF
--- a/src/routes/adminRouter.ts
+++ b/src/routes/adminRouter.ts
@@ -5,6 +5,10 @@ import { requireRole } from '../middleware/authMiddleware';
 
 const router = Router();
 
+// ── Auth gate — every admin route requires a verified admin or vendor session ──
+// (admin-users sub-routes below add their own stricter requireRole('admin') guard)
+router.use(requireRole('admin', 'vendor'));
+
 router.get('/vendors', AdminController.listVendors);
 router.post('/vendors', AdminController.createVendor);
 router.put('/vendors/:vendorId', AdminController.updateVendor);

--- a/src/routes/analyticsRouter.ts
+++ b/src/routes/analyticsRouter.ts
@@ -1,17 +1,18 @@
 import { Router } from 'express';
 import { AnalyticsController } from '../controllers/AnalyticsController';
+import { requireRole } from '../middleware/authMiddleware';
 
 const analyticsRouter = Router();
 
-// Read endpoints (admin dashboard)
-analyticsRouter.get('/summary', AnalyticsController.getSummary);
-analyticsRouter.get('/events/:eventId/items', AnalyticsController.getEventItemsBreakdown);
-analyticsRouter.get('/events/:eventId', AnalyticsController.getEventAnalytics);
-analyticsRouter.get('/items', AnalyticsController.getTopItems);
-analyticsRouter.get('/items/:itemId', AnalyticsController.getItemAnalytics);
-analyticsRouter.get('/events-leaderboard', AnalyticsController.getEventLeaderboard);
+// Read endpoints — require a verified admin or vendor session
+analyticsRouter.get('/summary',                  requireRole('admin', 'vendor'), AnalyticsController.getSummary);
+analyticsRouter.get('/events/:eventId/items',    requireRole('admin', 'vendor'), AnalyticsController.getEventItemsBreakdown);
+analyticsRouter.get('/events/:eventId',          requireRole('admin', 'vendor'), AnalyticsController.getEventAnalytics);
+analyticsRouter.get('/items',                    requireRole('admin', 'vendor'), AnalyticsController.getTopItems);
+analyticsRouter.get('/items/:itemId',            requireRole('admin', 'vendor'), AnalyticsController.getItemAnalytics);
+analyticsRouter.get('/events-leaderboard',       requireRole('admin', 'vendor'), AnalyticsController.getEventLeaderboard);
 
-// Write endpoint (frontend action tracking, fire-and-forget)
+// Write endpoint — public (customers fire this from menu/item pages, no token)
 analyticsRouter.post('/action', AnalyticsController.recordAction);
 
 export default analyticsRouter;


### PR DESCRIPTION
adminRouter: add router.use(requireRole('admin', 'vendor')) as the first middleware — previously every GET endpoint (vendors, events, menus, items, QR mappings, analytics summary) was fully public; any unauthenticated request returned 200 with real data.

analyticsRouter: add requireRole('admin', 'vendor') to every GET endpoint. POST /action is intentionally kept public — customers fire it from menu/item pages with no session token.

Confirmed via live test: tampered JWT → 401, fake JWT → 401, no token → 401, valid admin → 200, POST /action → 204.