### PR TITLE
fix: events with no time window treated as expired; add displayName+i…

### DIFF
--- a/src/models/dto/menuDetailResponse.dto.ts
+++ b/src/models/dto/menuDetailResponse.dto.ts
@@ -1,10 +1,12 @@
 export interface LineItemDTO {
   id: number;
   name: string;
+  displayName?: string;
   description?: string;
   isActive: boolean;
   createdAt: Date;
   itemType: string;
   enumType?: string;
+  image?: string | null;
   subCategoryLineItems?: LineItemDTO[];
 }

--- a/src/services/EventMenuMappingService.ts
+++ b/src/services/EventMenuMappingService.ts
@@ -9,8 +9,13 @@ export const EventMenuMappingService = {
 
     const event = mapping.event;
     const now = new Date();
-    const isEventActive = !!(event?.startTime && event?.endTime && event.startTime <= now && event.endTime >= now);
-    console.log('Mapping found in repo:', !!mapping, 'Event:', mapping?.event?.name, 'Menu:', mapping?.menu?.name);
+    // An event is active when:
+    //   • No start/end times are set (perpetual — typical for menus used year-round)
+    //   • OR the current time is within the configured window
+    // Previously, "no times" incorrectly returned false, causing the fallback
+    // (empty lineItems + "event expired" UI) for all freshly-created events.
+    const hasWindow = !!(event?.startTime && event?.endTime);
+    const isEventActive = !hasWindow || (event!.startTime! <= now && event!.endTime! >= now);
 
     return { mapping, isEventActive };
   }

--- a/src/utils/MapperUtil.ts
+++ b/src/utils/MapperUtil.ts
@@ -31,11 +31,13 @@ function mapLineItemsRecursively(
       return {
         id: item.id,
         name: item.name,
+        displayName: item.displayName ?? item.name,
         description: item.description,
         isActive: item.isActive,
         createdAt: item.createdAt,
         itemType: item.type,
         enumType: item.enumType,
+        image: item.image ?? null,
         subCategoryLineItems: subItems,
       };
     })


### PR DESCRIPTION
…mage to menu DTO

EventMenuMappingService: change isEventActive logic so events without start/end times return true (perpetually active) instead of false. Previously, every freshly-created event showed an empty menu and the 'event expired' warning because null times were treated as inactive. Only mark inactive when BOTH times are set AND current time is outside the window.

MapperUtil.mapLineItemsRecursively: include displayName (falls back to name if not set) and image so the menu listing carries the same display-name and thumbnail data as the item detail endpoint.

LineItemDTO: add displayName and image fields to the type.