### PR TITLE
feat: add per-menu elaborate item description setting

### DIFF
--- a/migrations/2026-09-05-menu-elaborate-descriptions.sql
+++ b/migrations/2026-09-05-menu-elaborate-descriptions.sql
@@ -1,0 +1,4 @@
+-- Per-menu toggle: show item thumbnail + price + tags on the public menu list
+-- (elaborate view) instead of just a truncated description (compact view). Safe to replay.
+ALTER TABLE public.menu
+  ADD COLUMN IF NOT EXISTS elaborate_descriptions boolean NOT NULL DEFAULT false;

--- a/src/app.ts
+++ b/src/app.ts
@@ -86,6 +86,7 @@ export async function runMigrations(): Promise<void> {
 
   // menu — editorial presentation settings used by public item pages
   await sequelize.query(`ALTER TABLE menu ADD COLUMN IF NOT EXISTS item_story_heading VARCHAR(80) NOT NULL DEFAULT 'The backstory'`).catch(() => {});
+  await sequelize.query(`ALTER TABLE menu ADD COLUMN IF NOT EXISTS elaborate_descriptions BOOLEAN NOT NULL DEFAULT false`).catch(() => {});
 
   // vendor — auth and contact-page columns
   await sequelize.query(`ALTER TABLE vendor ADD COLUMN IF NOT EXISTS logo_url      TEXT`).catch(() => {});

--- a/src/models/menu.model.ts
+++ b/src/models/menu.model.ts
@@ -35,6 +35,9 @@ export class Menu extends Model<Menu> {
   @Column({ field: 'item_story_heading', type: DataType.STRING(80), defaultValue: 'The backstory' })
   itemStoryHeading!: string;
 
+  @Column({ field: 'elaborate_descriptions', type: DataType.BOOLEAN, defaultValue: false })
+  elaborateDescriptions!: boolean;
+
   @Column({ field: 'is_active', type: DataType.BOOLEAN })
   isActive!: boolean;
 

--- a/src/services/AdminService.ts
+++ b/src/services/AdminService.ts
@@ -284,6 +284,7 @@ function cleanMenu(menu: Menu) {
     displayName: menu.displayName,
     description: menu.description,
     itemStoryHeading: menu.itemStoryHeading || 'The backstory',
+    elaborateDescriptions: menu.elaborateDescriptions ?? false,
     isActive: menu.isActive,
     vendorId: menu.vendorId,
     type: menu.getDataValue('type') ?? 'generic',
@@ -597,6 +598,7 @@ export const AdminService = {
       displayName: requireText(body.displayName, 'Menu display name'),
       description: body.description?.trim() || null,
       itemStoryHeading: body.itemStoryHeading?.trim().slice(0, 80) || 'The backstory',
+      elaborateDescriptions: Boolean(body.elaborateDescriptions),
       isActive: body.isActive !== undefined ? Boolean(body.isActive) : true,
       type: menuType,
       sourceMenuId: body.sourceMenuId ? Number(body.sourceMenuId) : null,
@@ -623,6 +625,9 @@ export const AdminService = {
       itemStoryHeading: body.itemStoryHeading !== undefined
         ? (body.itemStoryHeading?.trim().slice(0, 80) || 'The backstory')
         : menu.itemStoryHeading,
+      elaborateDescriptions: body.elaborateDescriptions !== undefined
+        ? Boolean(body.elaborateDescriptions)
+        : menu.elaborateDescriptions,
       isActive: body.isActive !== undefined ? Boolean(body.isActive) : menu.isActive,
     });
     await rewriteMenuQrDestinations(oldVendorId, vendorId, oldName, name);

--- a/src/utils/MapperUtil.ts
+++ b/src/utils/MapperUtil.ts
@@ -150,6 +150,7 @@ export const MapperUtil = {
         displayName: mapping.menu?.displayName,
         description: mapping.menu?.description,
         itemStoryHeading: mapping.menu?.itemStoryHeading || 'The backstory',
+        elaborateDescriptions: mapping.menu?.elaborateDescriptions ?? false,
         isActive: mapping.menu?.isActive,
         type: mapping.menu?.getDataValue?.('type') ?? 'generic',
         createdAt: mapping.menu?.createdAt,
@@ -172,6 +173,7 @@ export const MapperUtil = {
         displayName: mapping.menu?.displayName,
         description: mapping.menu?.description,
         itemStoryHeading: mapping.menu?.itemStoryHeading || 'The backstory',
+        elaborateDescriptions: mapping.menu?.elaborateDescriptions ?? false,
         isActive: mapping.menu?.isActive,
         type: mapping.menu?.getDataValue?.('type') ?? 'generic',
         createdAt: mapping.menu?.createdAt,
@@ -188,6 +190,7 @@ function getMenuSummary(menu: Menu) {
     displayName: menu.displayName,
     description: menu.description,
     itemStoryHeading: menu.itemStoryHeading || 'The backstory',
+    elaborateDescriptions: menu.elaborateDescriptions ?? false,
     isActive: menu.isActive,
     type: menu.getDataValue?.('type') ?? 'generic',
   }


### PR DESCRIPTION
Adds a menu-level elaborate_descriptions toggle so a vendor can opt in to showing item thumbnail, price and tags on the public menu list instead of just a truncated description. Off by default so existing menus render unchanged. Threaded through the Menu model, admin create/update endpoints, and the public menu API response.