### PR TITLE
fix: item image upload crashed on any real photo and on Node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "sequelize": "^6.37.7",
     "sequelize-typescript": "^2.1.4",
     "sharp": "^0.34.3",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "ws": "^8.21.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
@@ -37,6 +38,7 @@
     "@types/ioredis": "^4.28.10",
     "@types/multer": "^2.1.0",
     "@types/node": "^20.12.7",
+    "@types/ws": "^8.18.1",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,6 +42,19 @@ app.use((_req, res) => {
   res.status(404).json({ message: 'Route not found' });
 });
 
+// Catch-all error handler — without this, any thrown/next(err) error (e.g. a
+// Multer file-size rejection) falls through to Express's default HTML error
+// page: a raw stack trace with a 500, which breaks JSON-expecting clients and
+// leaks server file paths.
+app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  if (err?.code === 'LIMIT_FILE_SIZE') {
+    res.status(400).json({ message: 'Image must be 8 MB or smaller.' });
+    return;
+  }
+  console.error('Unhandled error:', err);
+  res.status(err?.status || 500).json({ message: err?.message || 'Something went wrong.' });
+});
+
 /**
  * runMigrations — idempotent column additions executed BEFORE the server
  * starts accepting traffic. Every statement uses IF NOT EXISTS / ON CONFLICT

--- a/src/routes/onboardingRouter.ts
+++ b/src/routes/onboardingRouter.ts
@@ -3,11 +3,17 @@ import multer from 'multer';
 import { OnboardingController } from '../controllers/OnboardingController';
 
 const router = Router({ mergeParams: true }); // inherit :vendorName from parent
-const previewImageTypes = new Set(['image/jpeg', 'image/png', 'image/webp']);
+// Matches the 8 MB limit the frontend already advertises to the user (was
+// mismatched at 1 MB here, so any real photo between 1-8 MB silently crashed
+// the request instead of failing with a clear error).
+// No fileFilter here: rejecting an unsupported type by silently dropping the
+// file (multer's fileFilter convention) left req.file undefined, which the
+// controller then reported as "No file provided" — misleading when a file
+// *was* selected. OnboardingService.uploadImage already does a proper
+// signature check and throws a specific, accurate error message instead.
 const upload = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 1024 * 1024, files: 1 },
-  fileFilter: (_req, file, callback) => callback(null, previewImageTypes.has(file.mimetype)),
+  limits: { fileSize: 8 * 1024 * 1024, files: 1 },
 });
 
 // ── Menus ─────────────────────────────────────────────────────────────────────

--- a/src/services/OnboardingService.ts
+++ b/src/services/OnboardingService.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import Razorpay from 'razorpay';
+import WebSocket from 'ws';
 import { createClient } from '@supabase/supabase-js';
 import { OnboardingRepo } from '../repositories/onboarding.repository';
 import {
@@ -24,7 +25,11 @@ function getRazorpay() {
 function getSupabase() {
   return createClient(
     process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_KEY!
+    process.env.SUPABASE_SERVICE_KEY!,
+    // Only Storage is used here, but the client eagerly constructs a
+    // RealtimeClient regardless, which throws on Node < 22 without a
+    // WebSocket global unless a transport is supplied explicitly.
+    { realtime: { transport: WebSocket as any } }
   );
 }
 
@@ -293,7 +298,7 @@ export const OnboardingService = {
       'image/webp': file.buffer.length >= 12 && file.buffer.toString('ascii', 0, 4) === 'RIFF' && file.buffer.toString('ascii', 8, 12) === 'WEBP',
     } as Record<string, boolean>;
     if (!signatures[file.mimetype]) throw Object.assign(new Error('Uploaded file is not a valid JPEG, PNG or WebP image'), { status: 400 });
-    if (file.size > 1024 * 1024) throw Object.assign(new Error('Image must be 1 MB or smaller'), { status: 400 });
+    if (file.size > 8 * 1024 * 1024) throw Object.assign(new Error('Image must be 8 MB or smaller'), { status: 400 });
     const ext = ({ 'image/jpeg': 'jpg', 'image/png': 'png', 'image/webp': 'webp' } as Record<string, string>)[file.mimetype];
     const fileName = `${vendorName}/${Date.now()}.${ext}`;
     const supabase = getSupabase();


### PR DESCRIPTION
Three compounding bugs in the onboarding image-upload endpoint:
- Multer capped uploads at 1MB while the frontend advertised 8MB, and there was no error-handling middleware anywhere in the app, so exceeding it (any normal phone photo) fell through to Express's default handler: a raw HTML stack trace with a 500, leaking server file paths. Limits now match at 8MB, and a global JSON error handler catches this (and any future unhandled error) instead of leaking output.
- @supabase/supabase-js eagerly constructs a RealtimeClient on createClient(), which throws without a WebSocket global — a hard failure on Node < 22 even though this endpoint only uses Storage. Added `ws` as the realtime transport to satisfy the constructor.
- Dropped the multer fileFilter that silently discarded unsupported file types (surfacing as a misleading "No file provided"); the existing signature check in OnboardingService.uploadImage already reports the correct, specific error.

Also created the missing `item-images` Supabase storage bucket that this code has expected all along.