### PR TITLE
feat: make the requireLogin re-nag interval DB-configurable

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -226,6 +226,10 @@ export async function runMigrations(): Promise<void> {
     INSERT INTO app_config (key, value) VALUES ('disable_inspect', 'false')
     ON CONFLICT (key) DO NOTHING
   `).catch(() => {});
+  await sequelize.query(`
+    INSERT INTO app_config (key, value) VALUES ('require_login_renag_ms', '5000')
+    ON CONFLICT (key) DO NOTHING
+  `).catch(() => {});
 
   console.log('✅ Migrations complete');
 }

--- a/src/controllers/PublicConfigController.ts
+++ b/src/controllers/PublicConfigController.ts
@@ -6,11 +6,22 @@
 import { Request, Response } from 'express';
 import { makeAppConfigReader } from '../utils/AppConfigUtil';
 
-const readDisableInspect = makeAppConfigReader('disable_inspect', 'false');
+const readDisableInspect     = makeAppConfigReader('disable_inspect', 'false');
+// How long the "please log in" nudge waits before reopening after a visitor dismisses it on a
+// vendor with requireLogin=true. Deliberately not a hard block — it's a nag, not an auth gate —
+// so it must stay dismissible; this only controls how persistent the nag is.
+// To change it: UPDATE app_config SET value = '10000' WHERE key = 'require_login_renag_ms';
+const readRequireLoginRenagMs = makeAppConfigReader('require_login_renag_ms', '5000');
 
 export const PublicConfigController = {
   async get(_req: Request, res: Response): Promise<void> {
-    const disableInspect = (await readDisableInspect()) === 'true';
-    res.json({ disableInspect });
+    const [disableInspect, requireLoginRenagMs] = await Promise.all([
+      readDisableInspect(),
+      readRequireLoginRenagMs(),
+    ]);
+    res.json({
+      disableInspect: disableInspect === 'true',
+      requireLoginRenagMs: Number(requireLoginRenagMs) || 5000,
+    });
   },
 };


### PR DESCRIPTION
New app_config key 'require_login_renag_ms' (default 5000), read via the existing public-config endpoint. Backs the frontend's dismissible login popup on vendors with requireLogin=true: it's a nag, not a hard gate, so it must stay closable, and this controls how soon it reopens after being dismissed without logging in.