### PR TITLE
fix: analytics CSV export was missing the phone column entirely

### DIFF
--- a/src/repositories/analytics.repository.ts
+++ b/src/repositories/analytics.repository.ts
@@ -784,6 +784,7 @@ export const AnalyticsRepo = {
          COALESCE(ae.qr_status, '—')                                          AS "QR Status",
          COALESCE(ae.device_type, 'unknown')                                   AS "Device",
          SUBSTRING(MD5(COALESCE(ae.user_agent, 'unknown')), 1, 8)             AS "Session ID",
+         COALESCE(ae.phone, '—')                                               AS "Phone",
          COALESCE(ae.referrer, '—')                                            AS "Referrer",
          COALESCE(ae.user_agent, '—')                                          AS "User Agent",
          COALESCE(v.display_name, '—')                                         AS "Vendor"


### PR DESCRIPTION
rawExport()'s SELECT never listed ae.phone, so the downloadable analytics spreadsheet had no Phone column at all — not just empty cells, the column didn't exist. The Event Log view (a separate query) already returned it correctly, which is what made this look like a capture bug rather than an export gap when first reported.